### PR TITLE
Added "subdomain" required option in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ accepts these credentials and calls `done` providing a user, as well as
     passport.use(new FreshbooksStrategy({
 
         // This is your Freshbooks subdomain.  e.g. `example` in `http://example.freshbooks.com`
+        subdomain: SUBDOMAIN,
         consumerKey: SUBDOMAIN,
 
         // This is your OAuth Secret from My Account -> Freshbooks API.


### PR DESCRIPTION
It seems the subdomain option is required, which is also used in the [example](https://github.com/MichaelJCole/passport-freshbooks/blob/master/examples/login/app.js#L69), but was missing in the ReadMe..
